### PR TITLE
Fix: Load model checkpoint dynamically on the correct device

### DIFF
--- a/src/brlp/networks.py
+++ b/src/brlp/networks.py
@@ -24,7 +24,12 @@ def load_if(checkpoints_path: Optional[str], network: nn.Module) -> nn.Module:
     """
     if checkpoints_path is not None:
         assert os.path.exists(checkpoints_path), 'Invalid path'
-        network.load_state_dict(torch.load(checkpoints_path))
+        
+        # Use the same device as the model
+        device = next(network.parameters()).device
+        
+        network.load_state_dict(torch.load(checkpoints_path, map_location=device))
+
     return network
 
 

--- a/src/brlp/networks.py
+++ b/src/brlp/networks.py
@@ -24,10 +24,7 @@ def load_if(checkpoints_path: Optional[str], network: nn.Module) -> nn.Module:
     """
     if checkpoints_path is not None:
         assert os.path.exists(checkpoints_path), 'Invalid path'
-        
-        # Use the same device as the model
-        device = next(network.parameters()).device
-        
+        device = next(network.parameters()).device # Use the same device as the model
         network.load_state_dict(torch.load(checkpoints_path, map_location=device))
 
     return network


### PR DESCRIPTION
This PR fixes a device mismatch issue when loading model checkpoints. The update ensures checkpoints are mapped to the same device as the network, preventing errors when switching between CPU and GPU.

## Changes:
- Dynamically map checkpoint to `network.parameters().device`.
## Why:
- Fixes crashes when loading GPU-trained models on CPU.
- Ensures seamless CPU/GPU compatibility.
